### PR TITLE
Bump cljsjs/jqconsole

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject cljs-browser-repl "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.145"]
-                 [cljsjs/jqconsole "2.11.0-1"]
+                 [cljsjs/jqconsole "2.12.0-0"]
                  [reagent "0.5.1"]
                  [com.cognitect/transit-clj "0.8.283"]
                  [com.cognitect/transit-cljs "0.8.225"]]

--- a/src/cljs/cljs_browser_repl/console.cljs
+++ b/src/cljs/cljs_browser_repl/console.cljs
@@ -8,19 +8,23 @@
   selector (any jQuery selector will work) and configuration. The
   options are passed as named parameters and follow the jq-console ones.
 
-  * welcome-string is the string to be shown when the terminal is first
-    rendered.
-  * prompt-label is the label to be shown before the input when using
-    Prompt().
-  * continue-label is the label to be shown before the continued lines
-    of the input when using Prompt().
-  * disable-auto-focus is a boolean indicating whether we should disable
-    the default auto-focus behavior.
+  * :welcome-string is the string to be shown when the terminal is first
+    rendered. Defaults to nil.
+  * :prompt-label is the label to be shown before the input when using
+    Prompt(). Defaults to \"$ \".
+  * :continue-label is the label to be shown before the continued lines
+    of the input when using Prompt(). Defaults to nil.
+  * :disable-auto-focus is a boolean indicating whether we should disable
+    the default auto-focus behavior. Defaults to false, the console always
+    focus.
 
   See https://github.com/replit/jq-console#instantiating"
-
-  [selector & {:keys [welcome-string prompt-label continue-label disable-auto-focus]
-               :or {welcome-string nil prompt-label ">> " continue-label nil disable-auto-focus nil}}]
+  [selector {:keys [welcome-string prompt-label continue-label disable-auto-focus]
+             :or {welcome-string nil
+                  prompt-label "$ "
+                  continue-label nil
+                  disable-auto-focus false}}]
+  (println welcome-string prompt-label continue-label disable-auto-focus)
   (-> (js/$ selector) (.jqconsole welcome-string prompt-label continue-label disable-auto-focus)))
 
 (defn write!

--- a/src/cljs/cljs_browser_repl/console/cljs.cljs
+++ b/src/cljs/cljs_browser_repl/console/cljs.cljs
@@ -25,11 +25,14 @@
                     (.SetPromptLabel console (bootstrap/get-prompt)) ;; necessary for namespace changes
                     (cljs-console-prompt! console)))))
 
-(defn cljs-console-did-mount []
+(defn cljs-console-did-mount
+  [console-opts]
   (js/$
    (fn []
      (let [jqconsole (console/new-jqconsole "#cljs-console"
-                                            :prompt-label (bootstrap/get-prompt))]
+                                            (merge {:prompt-label (bootstrap/get-prompt)
+                                                    :disable-auto-focus true}
+                                                   console-opts))]
        (app/add-console! :cljs-console jqconsole)
        (cljs-console-prompt! jqconsole)))))
 
@@ -38,11 +41,24 @@
    [:div#cljs-console.console.cljs-console]])
 
 (defn cljs-component
-  "A console for evaluating Clojure(Script) forms."
+  "Creates a new instance of e which loads on the input
+  selector (any jQuery selector will work) and configuration. The
+  options are passed as named parameters and follow the jq-console ones.
+
+  * :welcome-string is the string to be shown when the terminal is first
+    rendered. Defaults to nil.
+  * :prompt-label is the label to be shown before the input when using
+    Prompt(). Defaults to namespace=>.
+  * :continue-label is the label to be shown before the continued lines
+    of the input when using Prompt(). Defaults to nil.
+  * :disable-auto-focus is a boolean indicating whether we should disable
+    the default auto-focus behavior. Defaults to true, the console never
+    takes focus."
   []
-  (fn []
+  (fn [console-opts]
     (println "Initializing the ClojureScript REPL")
     (bootstrap/init-repl)
     (println "Building ClojureScript React component")
-    (reagent/create-class {:reagent-render cljs-console-render
-                           :component-did-mount cljs-console-did-mount})))
+    (reagent/create-class {:display-name "cljs-console-component"
+                           :reagent-render cljs-console-render
+                           :component-did-mount #(cljs-console-did-mount console-opts)})))


### PR DESCRIPTION
Bump cljsjs/jqconsole to 2.12-0 and fixes default values for cljs console.
