### PR TITLE
Fix warning not displayed and test for js/Error

### DIFF
--- a/src/cljs/cljs_bootstrap/common.cljs
+++ b/src/cljs/cljs_bootstrap/common.cljs
@@ -32,6 +32,11 @@
   [result]
   (and (string? result) (not (inline-newline? result))))
 
+(defn valid-eval-error?
+  "Is the string returned from an evaluation valid?"
+  [error]
+  (instance? js/Error error))
+
 (defn extract-message
   "Iteratively extracts messages inside (nested #error objects), returns
   a string. Be sure to pass #error object here."


### PR DESCRIPTION
Sorry, the name of the branch is misleading, this patch is about @22 and testing that when the eval returns an error, a actual `js/Error` is sent to the callback.
