### PR TITLE
Fix tests

### DIFF
--- a/src/cljs/cljs_bootstrap/common.cljs
+++ b/src/cljs/cljs_bootstrap/common.cljs
@@ -35,7 +35,7 @@
             (string/join " - " strings)
             "Error"))
         (when print-stack?
-          (str "\n" (string/join "\n" (drop 1 (string/split-lines (.-stack err)))))))))
+          (str "\n" (string/join "\n" (string/split-lines (.-stack err))))))))
 
 (defn echo-callback
   "Callback that just echoes the result map. It also asserts the correct

--- a/test/doo/launcher/runner.cljs
+++ b/test/doo/launcher/runner.cljs
@@ -5,6 +5,9 @@
             [cljs-bootstrap.repl-test]
             [cljs-bootstrap.common-test]))
 
+;; Add COMPILED flag to cljs eval to turn off namespace already declared errors
+(set! js/COMPILED true)
+
 (enable-console-print!)
 
 (doo-all-tests) ;; #"^cljs.*-test" not supported yet


### PR DESCRIPTION
Problem with PhanthomJS is that it not include stack traces of errors
that's why all test reeling on that will fail.
We can skip this kind of testes in phanthomjs or remove it, your call
( i would go with removing )

before merge need to update README if we remove PhanthomJS https://github.com/ScalaConsultants/cljs-browser-repl/issues/24
