### PR TITLE
Buttons tooltips; console focus

### DIFF
--- a/src/cljs/cljs_browser_repl/console.cljs
+++ b/src/cljs/cljs_browser_repl/console.cljs
@@ -85,3 +85,10 @@
   [console matchings]
   (doseq [[matching-name [opening closing]] matchings]
     (register-matching! console matching-name opening closing)))
+
+(defn focus-console!
+  "jqconsole wrapper, forces the focus onto the console so events can be 
+  captured."
+  [console]
+  (.Focus console))
+

--- a/src/cljs/cljs_browser_repl/console/cljs.cljs
+++ b/src/cljs/cljs_browser_repl/console/cljs.cljs
@@ -40,6 +40,14 @@
     (console/register-matchings! default-matchings)))
 
 (defn cljs-reset-console-and-prompt!
+  "Resets the console and forces the focus onto it."
   [console]
   (console/reset-console! console)
+  (console/focus-console! console)
   (cljs-console-prompt! console))
+
+(defn cljs-clear-console!
+  "Clears the console and put forces the focus onto it."
+  [console]
+  (console/clear-console! console)
+  (console/focus-console! console))

--- a/src/cljs/cljs_browser_repl/views.cljs
+++ b/src/cljs/cljs_browser_repl/views.cljs
@@ -57,15 +57,20 @@
                :md-icon-name "zmdi-delete"
                :on-click #(cljs/cljs-reset-console-and-prompt! (app/console :cljs-console))
                :class "cljs-btn"
+               :tooltip "Reset"
+               :tooltip-position :left-center
                :disabled? (not (app/console-created? :cljs-console))]
               [md-icon-button
                :md-icon-name "zmdi-format-clear-all"
-               :on-click #(console/clear-console! (app/console :cljs-console))
+               :on-click #(cljs/cljs-clear-console! (app/console :cljs-console))
                :class "cljs-btn"
+               :tooltip "Clear"
+               :tooltip-position :left-center
                :disabled? (not (app/console-created? :cljs-console))]
-              ;; copy to clipboard?
               [md-icon-button
                :md-icon-name "zmdi-github"
                :on-click #()
                :class "cljs-btn"
+               :tooltip "Create a Gist"
+               :tooltip-position :below-center
                :disabled? (not (app/console-created? :cljs-console))]]])


### PR DESCRIPTION
As in the title.

I’ve also deleted the “copy to clipboard” comment since it’s valid no more. 
