### PR TITLE
UI fixes

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -27,7 +27,7 @@
     </div>
     <div id="app-center" class="app-main">
       <div id="loading-div">
-        <h2>Loading parenthesis...</h2>
+        <h2 id="loading-h2">Loading parenthesis...</h2>
         <img src="img/loading_cljs.png" id="loading-img" alt="ClojureScript" />
       </div>
     </div>

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -14,7 +14,7 @@ body,html {
 }
 
 #app-center {
-    height: 100px;
+    height: 150px;
     width: 720px;
     left: 50%;
     margin-left: -360px;
@@ -30,6 +30,10 @@ body,html {
 
 #loading-div {
     text-align: center;
+}
+
+#loading-h2 {
+    color: #DDD;
 }
 
 /*
@@ -89,7 +93,7 @@ body,html {
     /*  Note that this element must be explicity sized and positioned absolute or relative. */
     position: relative;
     width: 660px;
-    height: 250px;
+    height: 300px;
     min-width: 300px;
     min-height: 185px;
 }
@@ -112,7 +116,7 @@ body,html {
     padding: 20px;
 }
 
-.rc-md-icon-button > i {
+.cljs-btn > i {
     color: #FFFFFF;
 }
 


### PR DESCRIPTION
Little fixes; most importantly the popover's arrow position, which was annoying to see.
Was:
<img width="436" alt="screen shot 2015-11-23 at 17 23 28" src="https://cloud.githubusercontent.com/assets/15321488/11342302/f1c9d9d6-9206-11e5-8e8e-06ef2c5b7fa2.png">
And is:
<img width="433" alt="screen shot 2015-11-23 at 17 24 10" src="https://cloud.githubusercontent.com/assets/15321488/11342314/0807eb7a-9207-11e5-8556-6e56a14de595.png">
