### PR TITLE
Double console fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                  [reagent "0.5.1"]
                  [re-frame "0.5.0"]
                  [re-com "0.7.0-alpha2"]
-                 [timothypratley/reanimated "0.1.1"]
                  [cljs-ajax "0.5.1"]
                  [endophile "0.1.2"]
                  [markdown-clj "0.9.78"]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -1,7 +1,6 @@
 (ns cljs-repl-web.views
   (:require-macros [re-com.core :refer [handler-fn]])
   (:require [reagent.core :as reagent]
-            [timothypratley.reanimated.core :as anim]
             [re-frame.core :refer [subscribe dispatch]]
             [re-com.core :refer [md-icon-button h-box v-box box gap button input-text
                                  popover-content-wrapper popover-anchor-wrapper hyperlink-href
@@ -541,14 +540,13 @@
    :children [[api-panel]]])
 
 (defn repl-component []
-  [anim/pop-when true
-   [h-box
-    :class "app-main"
-    :size "1 1 auto"
-    :justify :center
-    :gap "10px"
-    :children [[cljs-buttons]
-               [box
-                :size "1"
-                :style {:overflow "hidden"}
-                :child [cljs-console-component]]]]])
+  [h-box
+   :class "app-main"
+   :size "1 1 auto"
+   :justify :center
+   :gap "10px"
+   :children [[cljs-buttons]
+              [box
+               :size "1"
+               :style {:overflow "hidden"}
+               :child [cljs-console-component]]]])


### PR DESCRIPTION
Two small fixes on this one, please have a look:
1. suppress a `:key` warning
2. remove `reanimated` as we have just one animation and it was causing console to be created twice (probably a bug on the lib)
