### PR TITLE
Delete binding symbol since uses "println"

### DIFF
--- a/src/cljs/cljs_repl_web/cljs_api/utils.cljs
+++ b/src/cljs/cljs_repl_web/cljs_api/utils.cljs
@@ -54,7 +54,7 @@
                          (Topic. "nesting, chaining, and interop"
                                  '(-> ->> doto .. .))
                          (Topic. "defining things"
-                                 '(def defn fn let letfn binding defmulti defmethod
+                                 '(def defn fn let letfn defmulti defmethod
                                     deftype defrecord reify this-as declare ns))])
 
 


### PR DESCRIPTION
Same as with `loop`. We'll need a way to print to the repl.
