### PR TITLE
Focus console on page load

### DIFF
--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -29,7 +29,8 @@
    (fn []
      (let [jqconsole (cljs/cljs-console! console-opts)]
        (dispatch [:add-console :cljs-console jqconsole])
-       (cljs/cljs-console-prompt! jqconsole)))))
+       (cljs/cljs-console-prompt! jqconsole)
+       (console/focus-console! jqconsole)))))
 
 (defn cljs-console-render []
   [:div.cljs-console.console])


### PR DESCRIPTION
I put it in `cljs-console-did-mount` to emphasise the focus on creation.
