### PR TITLE
Focus on app center

### DIFF
--- a/src/cljs/cljs_repl_web/handlers.cljs
+++ b/src/cljs/cljs_repl_web/handlers.cljs
@@ -1,5 +1,6 @@
 (ns cljs-repl-web.handlers
   (:require [re-frame.core :refer [register-handler]]
+            [reagent.core :as r]
             [replumb.core :as replumb]
             [clairvoyant.core :refer-macros [trace-forms]]
             [re-frame-tracer.core :refer [tracer]]
@@ -166,3 +167,14 @@
    (assoc db :media-query-size media-matched)))
 
 ;; )
+
+
+;;;;;;;;;;;;;;;;;;;;;;
+;;;  Side Effects  ;;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+(register-handler
+ :focus-on-load
+ (fn focus-on-load [db [_ id]]
+   (.scrollIntoView (r/dom-node id))
+   db))

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -417,31 +417,31 @@
   (let [showing? (reagent/atom false)
         popover-position (reagent/atom :below-center)]
     (fn api-symbol-form2 [symbol]
-     [box
-      :size "0 1 auto"
-      :align :center
-      :class "api-panel-symbol-label-box"
-      :child (if-let [symbol (get-symbol-doc-map (str symbol))]
-               [popover-anchor-wrapper
-                :showing? showing?
-                :position @popover-position
-                :anchor [button
-                         :class "btn btn-default api-panel-symbol-button"
-                         :label (:name symbol)
-                         ;; we use :attr's `:on-click` because button's `on-click` accepts
-                         ;; a parametless function and we need the mouse click coordinates
-                         :attr { :on-click
-                                (handler-fn
-                                 ;; later we can refactor it into re-frame
-                                 ;; see also https://github.com/Day8/re-frame/wiki/Beware-Returning-False#user-content-usage-examples
-                                 (reset! popover-position
-                                         (utils/calculate-popover-position [(.-clientX event) (.-clientY event)]))
-                                 (reset! showing? true))}]
-                :popover [symbol-popover showing? popover-position symbol]]
-               [label
-                :label (str symbol)
-                :class "api-panel-symbol-label"
-                :style (flex-child-style "80 1 auto")])])))
+      [box
+       :size "0 1 auto"
+       :align :center
+       :class "api-panel-symbol-label-box"
+       :child (if-let [symbol (get-symbol-doc-map (str symbol))]
+                [popover-anchor-wrapper
+                 :showing? showing?
+                 :position @popover-position
+                 :anchor [button
+                          :class "btn btn-default api-panel-symbol-button"
+                          :label (:name symbol)
+                          ;; we use :attr's `:on-click` because button's `on-click` accepts
+                          ;; a parametless function and we need the mouse click coordinates
+                          :attr { :on-click
+                                 (handler-fn
+                                  ;; later we can refactor it into re-frame
+                                  ;; see also https://github.com/Day8/re-frame/wiki/Beware-Returning-False#user-content-usage-examples
+                                  (reset! popover-position
+                                          (utils/calculate-popover-position [(.-clientX event) (.-clientY event)]))
+                                  (reset! showing? true))}]
+                 :popover [symbol-popover showing? popover-position symbol]]
+                [label
+                 :label (str symbol)
+                 :class "api-panel-symbol-label"
+                 :style (flex-child-style "80 1 auto")])])))
 
 (defn section-title-component
   [section-title]
@@ -598,7 +598,8 @@
                        :style {:overflow "hidden"}
                        :child [cljs-console-component]]]]
         (if (= :narrow @media-query)
-          [v-box
+          [(with-meta v-box
+             {:component-did-mount #(dispatch [:focus-on-load %])})
            :size "1 1 auto"
            :align :center
            :gap "10px"


### PR DESCRIPTION
# What's new
- Disable auto-focus for console element
- Focus' on console with buttons (v-box) on mobile.
  It's not a real focus, as div elements don't support focus.
  Instead, we are using scrollIntoView when component (v-box)
  is mounted to dom, which essentially does the same thing.
  Another option how to do it would be to assign v-box div some
  id and upon component-did-mount, change the location hash in url
  to that id.
