### PR TITLE
Prepare datastate for more repls

### DIFF
--- a/src/cljs/cljs_repl_web/app.cljs
+++ b/src/cljs/cljs_repl_web/app.cljs
@@ -18,13 +18,13 @@
 (defn console
   "Given a db and console key, returns its instance or nil if not
   found."
-  [db k]
-  (get-in db [:consoles (name k) :console]))
+  [db console-id]
+  (get-in db [:consoles console-id :console]))
 
 (defn console-text
   "Given a db, returns the console text or nil if none found."
-  [db k]
-  (get-in db [:consoles (name k) :text]))
+  [db console-id]
+  (get-in db [:consoles console-id :text]))
 
 (def console-created? "Was the console created? Returns a truey or falsey value."
   console)
@@ -32,15 +32,15 @@
 (defn assoc-console-text!
   "For the consoles in db, fetch the current text and assoc it
   to its console map (:text keyword)"
-  [db console-key text]
+  [db console-id text]
   {:post [(map? (:consoles %))]}
-  (assoc-in db [:consoles (name console-key) :text] text))
+  (assoc-in db [:consoles console-id :text] text))
 
 (defn interactive-examples
   "Given a db and console key, returns its examples or nil if not
   found."
-  [db k]
-  (get-in db [:consoles (name k) :interactive-examples]))
+  [db console-id]
+  (get-in db [:consoles console-id :interactive-examples]))
 
 (defn gist-showing?
   "Given a db, indicates if the gist login dialog is shown.

--- a/src/cljs/cljs_repl_web/console.cljs
+++ b/src/cljs/cljs_repl_web/console.cljs
@@ -20,8 +20,8 @@
     focus.
 
   See https://github.com/replit/jq-console#instantiating"
-  [selector {:keys [welcome-string prompt-label continue-label disable-auto-focus]}]
-  (-> (js/$ selector) (.jqconsole welcome-string prompt-label continue-label disable-auto-focus)))
+  [dom-node {:keys [welcome-string prompt-label continue-label disable-auto-focus]}]
+  (-> dom-node js/$ (.jqconsole welcome-string prompt-label continue-label disable-auto-focus)))
 
 (defn write!
   "Writes a message to the input console. Type is used as class inside

--- a/src/cljs/cljs_repl_web/console/cljs.cljs
+++ b/src/cljs/cljs_repl_web/console/cljs.cljs
@@ -28,9 +28,9 @@
       (console/write-exception! console err))))
 
 (defn cljs-console-set-prompt-text!
-  [console text]
+  [console-id console text]
   (console/set-prompt-text! console text)
-  (dispatch [:set-console-text :cljs-console text]))
+  (dispatch [:set-console-text console-id text]))
 
 (defn cljs-console-get-prompt-text!
   "Get the current text, prompt not included, unlike jqconsole's."
@@ -67,22 +67,22 @@
           :verbose false}))
 
 (defn cljs-console-prompt!
-  [console repl-opts]
+  [console console-id repl-opts]
   (.Prompt console true
            (fn [input]
              (cljs-read-eval-print! console repl-opts input)
              (.SetPromptLabel console (replumb/get-prompt)) ;; necessary for namespace changes
-             (cljs-console-prompt! console repl-opts)
-             (dispatch [:set-console-text :cljs-console input]))
+             (cljs-console-prompt! console console-id repl-opts)
+             (dispatch [:set-console-text console-id input]))
            cljs-console-multiline?)
-  (when-let [example @(subscribe [:get-next-example :cljs-console])]
+  (when-let [example @(subscribe [:get-next-example console-id])]
     (cljs-console-set-prompt-text! console example)
-    (dispatch [:delete-first-example :cljs-console])))
+    (dispatch [:delete-first-example console-id])))
 
 (defn cljs-console!
   "Create a console for ClojureScript."
-  [console-opts]
-  (doto (console/new-jqconsole ".cljs-console"
+  [dom-node console-opts]
+  (doto (console/new-jqconsole dom-node
                                (merge {:prompt-label (replumb/get-prompt)
                                        :disable-auto-focus false
                                        :continue-label "  "}
@@ -94,10 +94,10 @@
 
 (defn cljs-reset-console-and-prompt!
   "Resets the console and forces the focus onto it."
-  [console repl-opts]
+  [console console-id repl-opts]
   (console/reset-console! console)
   (console/focus-console! console)
-  (cljs-console-prompt! console repl-opts))
+  (cljs-console-prompt! console console-id repl-opts))
 
 (defn cljs-clear-console!
   "Clears the console and put forces the focus onto it."

--- a/src/cljs/cljs_repl_web/subs.cljs
+++ b/src/cljs/cljs_repl_web/subs.cljs
@@ -15,21 +15,27 @@
 
 (register-sub
  :console-created?
- (fn [db [_ console-key]]
+ (fn [db [_ console-id]]
    (make-reaction (fn console-created? []
-                    (app/console-created? @db console-key)))))
+                    (app/console-created? @db console-id)))))
 
 (register-sub
  :get-console
- (fn [db [_ console-key]]
+ (fn [db [_ console-id]]
    (make-reaction (fn get-console []
-                    (app/console @db console-key)))))
+                    (app/console @db console-id)))))
+
+(register-sub
+ :get-consoles
+ (fn [db _]
+   (make-reaction (fn []
+                    (:consoles @db)))))
 
 (register-sub
  :console-text
- (fn [db [_ console-key]]
+ (fn [db [_ console-id]]
    (make-reaction (fn console-text []
-                    (app/console-text @db console-key)))))
+                    (app/console-text @db console-id)))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;     APIs    ;;;
@@ -69,9 +75,9 @@
 
 (register-sub
  :example-mode?
- (fn [db [_ console-key]]
+ (fn [db [_ console-id]]
    (make-reaction (fn example-mode? []
-                    (not (empty? (app/interactive-examples @db console-key)))))))
+                    (not (empty? (app/interactive-examples @db console-id)))))))
 
 ;;;;;;;;;;;;;;;;;;
 ;;   Footer    ;;;
@@ -108,9 +114,9 @@
 
 (register-sub
  :can-dump-gist?
- (fn [db [_ console-key]]
-   (let [console (subscribe [:get-console console-key])
-         console-text (subscribe [:console-text console-key])]
+ (fn [db [_ console-id]]
+   (let [console (subscribe [:get-console console-id])
+         console-text (subscribe [:console-text console-id])]
      (make-reaction (fn can-save-gist? []
                       (let [_ @console-text] ;; using this just as trigger
                         (some-> @console (console/dump-console!) empty?)))))))


### PR DESCRIPTION
# What's new

* console-id is not hardcoded
* add new console by adding map with console-id and nil value into default db state
* every console has it's own buttons (clear, gist ..)

We really need to move away from jquery terminal as it's pain to work with (console required that target DOM element is already rendered on the page etc..)