### PR TITLE
Boot cljs repl fix2

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -61,7 +61,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;
 
 (def dev-compiler-options
-  {:source-map-timestamp true})
+  {:source-map-timestamp true
+   :elide-asserts true
+   :closure-defines {"clairvoyant.core.devmode" true}})
 
 (def prod-compiler-options
   {:closure-defines {"goog.DEBUG" false}

--- a/build.boot
+++ b/build.boot
@@ -30,7 +30,7 @@
                  [cljsjs/enquire              "2.1.2-0"]
                  [com.cemerick/piggieback     "0.2.1"]
                  [org.clojars.stumitchell/clairvoyant "0.2.0"]
-                 [binaryage/devtools          "0.5.2"]
+                 [binaryage/devtools          "0.6.0"]
                  [day8/re-frame-tracer        "0.1.0-SNAPSHOT"]
                  [cljsjs/codemirror           "5.10.0-0"]
                  [adzerk/cljs-console "0.1.1"]])


### PR DESCRIPTION
There was a problem in `build.boot` which was breaking `boot-cljs-repl`.

Plus devtools is now at `0.6.0`