### PR TITLE
better multiline handling

### DIFF
--- a/src/cljs/cljs_repl_web/replumb_proxy.cljs
+++ b/src/cljs/cljs_repl_web/replumb_proxy.cljs
@@ -33,7 +33,7 @@
     false
     (catch :default e
       (log/warn "multiline? caught @{e}")
-      true)))
+      (= "EOF" (subs (.-message e) 0 3)))))
 
 (defn eval-opts
   [verbose src-path]


### PR DESCRIPTION
Currently the repl gets stuck in multiline mode if an error like "unmatched delimiter" occurs.