### PR TITLE
Update re-console for parinfer fixe, closes #192

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -22,7 +22,7 @@
                  [re-frame                    "0.5.0"]
                  [replumb/replumb             "0.2.2-SNAPSHOT"]
                  [cljsjs/highlight            "8.4-0"]
-                 [re-console                  "0.1.2-SNAPSHOT"]
+                 [re-console                  "0.1.2"]
                  [re-com                      "0.7.0-alpha2"]
                  [cljs-ajax                   "0.5.1"]
                  [hickory                     "0.5.4"]


### PR DESCRIPTION
See https://github.com/Lambda-X/re-console/releases/tag/0.1.2