### PR TITLE
popup-tour 

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -28,7 +28,7 @@
                        [replumb/replumb             "0.2.2-SNAPSHOT"]
                        [cljsjs/highlight            "8.4-0"]
                        [re-console                  "0.1.4-SNAPSHOT"]
-                       [re-com                      "0.7.0-alpha2"]
+                       [re-com                      "0.8.1"]
                        [cljs-ajax                   "0.5.1"]
                        [hickory                     "0.5.4"]
                        [cljsjs/showdown             "0.4.0-1"]

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -394,10 +394,6 @@ body,html {
     align-self: center !important;
 }
 
-.welcome-popup div:parent {
-    margin-top: 150px;
-}
-
 h1.tour-title {
     margin-top: 5px;
     color: rgba(68, 68, 68, 0.6);
@@ -424,6 +420,11 @@ ul.tour {
     border: 1px solid rgba(128, 128, 128, 0.15);
     border-radius: 5px;
     background-color: #eee;
+}
+
+a.tour {
+    color:#337ab7;
+    text-decoration: none;
 }
 
 /* Some examples contains tables in their markdown.
@@ -544,7 +545,7 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     }
 
 
-    .welcome-popup {
+    .modal-tour-popup {
         width: 250px;
     }
 

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -378,6 +378,17 @@ body,html {
     border: none;
 }
 
+/*********************/
+/***     Tour      ***/
+/*********************/
+
+
+.rc-v-box .rc-popover-anchor-wrapper .rc-point-wrapper {
+    /*align-items: stretch !important;*/
+    /*flex: 0 1 auto !important;*/
+    flex-flow: row !important;
+}
+
 /* Some examples contains tables in their markdown.
  * These tables have a class of "code-tbl-9bef6"
  * see: http://stackoverflow.com/questions/5110249/wildcard-in-css-for-classes
@@ -425,6 +436,9 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     /* shadow */
     text-shadow: 0 0 5px #444;
 }
+
+
+
 
 /* :narrow */
 @media only screen and (max-width: 480px) {

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -520,6 +520,12 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     min-width: 300px;
 }
 
+.popup-tour-console-anchor {
+    width: 660px;
+    min-width: 300px;
+    height: 0;
+}
+
 /* :narrow */
 @media only screen and (max-width: 480px) {
     .re-console-container {
@@ -533,6 +539,11 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
 
     .re-console-mode-line {
         font-size: 10px;
+        width: 300px;
+        min-width: 120px;
+    }
+
+    .popup-tour-console-anchor {
         width: 300px;
         min-width: 120px;
     }
@@ -559,6 +570,11 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     }
 
     .re-console-mode-line {
+        width: 460px;
+        min-width: 220px;
+    }
+
+    .popup-tour-console-anchor {
         width: 460px;
         min-width: 220px;
     }

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -475,9 +475,6 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     text-shadow: 0 0 5px #444;
 }
 
-
-
-
 /* :narrow */
 @media only screen and (max-width: 480px) {
     .ribbon {
@@ -543,7 +540,6 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     #app-bottom {
         margin-top: 28px;
     }
-
 
     .modal-tour-popup {
         width: 250px;

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -394,6 +394,37 @@ body,html {
     align-self: center !important;
 }
 
+.welcome-popup div:parent {
+    margin-top: 150px;
+}
+
+h1.tour-title {
+    margin-top: 5px;
+    color: rgba(68, 68, 68, 0.6);
+    font-weight: bold;
+    font-size: 17px;
+}
+
+ul.tour {
+    -webkit-padding-start: 20px;
+    padding-start: 20px;
+}
+
+.symbol {
+    font-weight: bold;
+    color: #a50;
+    font-size: 110%;
+}
+
+.mode {
+    display:inline-block;
+    color: #a50;
+    padding: 4px;
+    font-size: 95%;
+    border: 1px solid rgba(128, 128, 128, 0.15);
+    border-radius: 5px;
+    background-color: #eee;
+}
 
 /* Some examples contains tables in their markdown.
  * These tables have a class of "code-tbl-9bef6"
@@ -511,6 +542,12 @@ table[class^="code-tbl-"] td, table[class*=" code-tbl-"] td {
     #app-bottom {
         margin-top: 28px;
     }
+
+
+    .welcome-popup {
+        width: 250px;
+    }
+
 }
 
 /* :medium */

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -365,6 +365,7 @@ body,html {
 }
 
 .api-panel-button-send-repl {
+    align-items: stretch !important;
     border: 0;
 }
 
@@ -384,10 +385,15 @@ body,html {
 
 
 .rc-v-box .rc-popover-anchor-wrapper .rc-point-wrapper {
-    /*align-items: stretch !important;*/
+    align-items: stretch !important;
     /*flex: 0 1 auto !important;*/
-    flex-flow: row !important;
+    /*flex-flow: row !important;*/
 }
+
+.rc-v-box .rc-popover-anchor-wrapper .rc-point-wrapper .rc-popover-point {
+    align-self: center !important;
+}
+
 
 /* Some examples contains tables in their markdown.
  * These tables have a class of "code-tbl-9bef6"

--- a/resources/public/styles/css/app.css
+++ b/resources/public/styles/css/app.css
@@ -586,8 +586,8 @@ ul.re-completion-list {
     position: absolute;
     margin: 0;
     padding: 0;
-    left: 364px;
-    top: 26px;
+    /* left: 364px; */
+    /* top: 26px; */
     min-height: 24px;
     max-height: 123px;
     width: 220px;

--- a/src/cljs/cljs_repl_web/core.cljs
+++ b/src/cljs/cljs_repl_web/core.cljs
@@ -41,8 +41,4 @@
                                                                              (utils/align-suggestions-list %2))}]
                     (.getElementById js/document "app-center"))
     (reagent/render [views/bottom-panel] (.getElementById js/document "app-bottom"))
-    (reagent/render [views/footer-component] (.getElementById js/document "app-footer"))
-    (comment (let [first-bottom-panel-item (dom/getElementByClass "api-panel-symbol-label-box")
-                   item-coordinates (.getBoundingClientRect (dom/getElementByClass "api-panel-symbol-label-box"))
-                   item-popup-position (utils/calculate-popover-position [(.-top item-coordinates) (.-left item-coordinates)])]
-               (views/create-tour-step 7 item-popup-position first-bottom-panel-item)))))
+    (reagent/render [views/footer-component] (.getElementById js/document "app-footer"))))

--- a/src/cljs/cljs_repl_web/core.cljs
+++ b/src/cljs/cljs_repl_web/core.cljs
@@ -1,6 +1,6 @@
 (ns cljs-repl-web.core
   (:require [reagent.core :as reagent]
-            [re-frame.core :refer [dispatch dispatch-sync subscribe]]
+            [re-frame.core :refer [dispatch dispatch-sync]]
             [re-com.core :refer [p h-box v-box box gap line]]
             [devtools.core :as devtools]
             [cljs-repl-web.handlers]

--- a/src/cljs/cljs_repl_web/core.cljs
+++ b/src/cljs/cljs_repl_web/core.cljs
@@ -12,7 +12,8 @@
             [cljs-repl-web.localstorage :as ls]
             [cljs-repl-web.app :as app]
             [re-console.common :as common]
-            [re-complete.core :as re-complete]))
+            [re-complete.core :as re-complete]
+            [goog.dom :as dom]))
 
 (defonce console-key :cljs-console)
 
@@ -40,4 +41,8 @@
                                                                              (utils/align-suggestions-list %2))}]
                     (.getElementById js/document "app-center"))
     (reagent/render [views/bottom-panel] (.getElementById js/document "app-bottom"))
-    (reagent/render [views/footer-component] (.getElementById js/document "app-footer"))))
+    (reagent/render [views/footer-component] (.getElementById js/document "app-footer"))
+    (comment (let [first-bottom-panel-item (dom/getElementByClass "api-panel-symbol-label-box")
+                   item-coordinates (.getBoundingClientRect (dom/getElementByClass "api-panel-symbol-label-box"))
+                   item-popup-position (utils/calculate-popover-position [(.-top item-coordinates) (.-left item-coordinates)])]
+               (views/create-tour-step 7 item-popup-position first-bottom-panel-item)))))

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -109,7 +109,7 @@
       :popover [popover-content-wrapper
                 :showing? (step-keyword tour)
                 :position position
-                :width    "250px"
+                :width    "200px"
                 :title    [:strong (get-in tour-steps [step-keyword :title])]
                 :body     [:div (get-in tour-steps [step-keyword :body])
                            [tour-buttons tour another-step close-fn]]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -27,22 +27,24 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def tour
-  (make-tour [:step1 :step2 :step3 :step4 :step5 :step6 :step7]))
+  (make-tour [:step1 :step2 :step3 :step4 :step5 :step6 :step7 :step8]))
 
 (def tour-steps
-  {:step1 {:title "Tour 1 of 7"
+  {:step1 {:title "Tour 1 of 8"
            :body "Reset"}
-   :step2 {:title "Tour 2 of 7"
+   :step2 {:title "Tour 2 of 8"
            :body "Clear"}
-   :step3 {:title "Tour 3 of 7"
+   :step3 {:title "Tour 3 of 8"
            :body "Create Gist"}
-   :step4 {:title "Tour 4 of 7"
+   :step4 {:title "Tour 4 of 8"
            :body "Clear examples"}
-   :step5 {:title "Tour 5 of 7"
+   :step5 {:title "Tour 5 of 8"
            :body "Switch input mode"}
-   :step6 {:title "Tour 6 of 7"
+   :step6 {:title "Tour 6 of 8"
            :body "Console"}
-   :step7 {:title "Tour 7 of 7"
+   :step7 {:title "Tour 7 of 8"
+           :body "Symbol"}
+   :step8 {:title "Tour 8 of 8"
            :body "Send to repl"}})
 
 (defn create-tour-step
@@ -62,7 +64,7 @@
                 :body     [:div (get-in tour-steps [step-keyword :body])
                            [make-tour-nav tour]]
                 :on-cancel #(do (finish-tour tour)
-                                (local-storage/set-item! :closed-tour? true))] 
+                                (local-storage/set-item! :closed-tour? true))]
       :style  (if style
                 style
                 (align-style :align-self :center))])))
@@ -468,23 +470,38 @@
        :size "0 1 auto"
        :align :center
        :class "api-panel-symbol-label-box"
-       :child (if-let [symbol (get-symbol-doc-map (str symbol))]
-                [popover-anchor-wrapper
-                 :showing? showing?
-                 :position @popover-position
-                 :anchor [button
-                          :class "btn btn-default api-panel-symbol-button"
-                          :label (:name symbol)
-                          ;; we use :attr's `:on-click` because button's `on-click` accepts
-                          ;; a parametless function and we need the mouse click coordinates
-                          :attr {:on-click
-                                 (handler-fn
-                                  ;; later we can refactor it into re-frame
-                                  ;; see also https://github.com/Day8/re-frame/wiki/Beware-Returning-False#user-content-usage-examples
-                                  (reset! popover-position
-                                          (utils/calculate-popover-position [(.-clientX event) (.-clientY event)]))
-                                  (reset! showing? true))}]
-                 :popover [symbol-popover showing? popover-position symbol]]
+       :child (if-let [symbol' (get-symbol-doc-map (str symbol))]
+                (if (and (= (str symbol) "+") (not @showing?))
+                  [create-tour-step 7
+                   :below-center
+                   [button
+                    :class "btn btn-default api-panel-symbol-button"
+                    :label (:name symbol')
+                    ;; we use :attr's `:on-click` because button's `on-click` accepts
+                    ;; a parametless function and we need the mouse click coordinates
+                    :attr {:on-click
+                           (handler-fn
+                            ;; later we can refactor it into re-frame
+                            ;; see also https://github.com/Day8/re-frame/wiki/Beware-Returning-False#user-content-usage-examples
+                            (reset! popover-position
+                                    (utils/calculate-popover-position [(.-clientX event) (.-clientY event)]))
+                            (reset! showing? true))}]]
+                  [popover-anchor-wrapper
+                   :showing? showing?
+                   :position @popover-position
+                   :anchor [button
+                            :class "btn btn-default api-panel-symbol-button"
+                            :label (:name symbol')
+                            ;; we use :attr's `:on-click` because button's `on-click` accepts
+                            ;; a parametless function and we need the mouse click coordinates
+                            :attr {:on-click
+                                   (handler-fn
+                                    ;; later we can refactor it into re-frame
+                                    ;; see also https://github.com/Day8/re-frame/wiki/Beware-Returning-False#user-content-usage-examples
+                                    (reset! popover-position
+                                            (utils/calculate-popover-position [(.-clientX event) (.-clientY event)]))
+                                    (reset! showing? true))}]
+                   :popover [symbol-popover showing? popover-position symbol']])
                 [label
                  :label (str symbol)
                  :class "api-panel-symbol-label"

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -31,6 +31,8 @@
 (def tour
   (make-tour [:step1 :step2 :step3 :step4 :step5 :step6 :step7 :step8 :step9 :step10]))
 
+(def current-step (reagent/atom @(:current-step tour)))
+
 (def tour-steps
   {:welcome {:title "Welcome to clojurescript.io!"
              :body [:div [:p "Here you will find a terminal-like REPL which you can use when learning Clojure/ClojureScript or just trying new things out."]
@@ -105,8 +107,11 @@
                    [:li "related symbols list"]]]}
    :step9 {:title  "Tour 9 of 9"
            :body [:div [:h1.tour-title "Send to repl"]
-                  [:p "click on this button to send the examples to the REPL"]]}})
-
+                  [:p "click on this button to send the examples to the REPL"]]}
+   :step10 {:title  "Excellent!"
+            :body [:div [:p "This is the end of the tutorial. If you want to report an issue or fork the repository click on the ribbon in the top-left corner."]
+                   [:p "Check also our blog at lambdax.io/blog for posts about Clojure and follow us on Twitter at @lambdax_io."]
+                   [:p "Thanks and enjoy."]]}})
 
 (defn welcome-modal-dialog
   []
@@ -144,36 +149,34 @@
          :style {:padding-bottom "150px"}]))))
 
 (defn finished-tour-modal-dialog
-  [current-step]
+  []
   (let [showing? (reagent/atom true)]
     (fn []
-      (.log js/console "test")
-      (let [finished-tour? (= current-step (dec (count (:steps tour))))]
-        (.log js/console "finished-tour?" finished-tour?)
-        (when (and @showing? finished-tour?)
-          [modal-panel
-           :backdrop-opacity 0.4
-           :child [v-box
-                   :align :center
-                   :max-width "400px"
-                   :class "welcome-popup"
-                   :children [[title
-                               :label (get-in tour-steps [:welcome :title])
-                               :style {:font-weight "bold"
-                                       :font-size "20px"
-                                       :text-align "center"
-                                       :color "rgba(68, 68, 68, 0.6)"}]
-                              [p (get-in tour-steps [:welcome :body])]
-                              [:hr {:style {:margin "10px 0 10px"}}]
-                              [button
-                               :label "finish"
-                               :on-click #(do (finish-tour tour)
-                                              (ls/set-item! :closed-tour? true)
-                                              (reset! showing? false))
-                               :class "btn-default"
-                               :style {:margin-right "15px"}]]
-                   :style {:display "inline-block"}]
-           :style {:padding-bottom "150px"}])))))
+      (.log js/console "current-step?" @current-step)
+      (when (and @showing? (= @current-step (dec (count (:steps tour)))))
+        [modal-panel
+         :backdrop-opacity 0.4
+         :child [v-box
+                 :align :center
+                 :max-width "400px"
+                 :class "welcome-popup"
+                 :children [[title
+                             :label (get-in tour-steps [:step10 :title])
+                             :style {:font-weight "bold"
+                                     :font-size "20px"
+                                     :text-align "center"
+                                     :color "rgba(68, 68, 68, 0.6)"}]
+                            [p (get-in tour-steps [:step10 :body])]
+                            [:hr {:style {:margin "10px 0 10px"}}]
+                            [button
+                             :label "finish"
+                             :on-click #(do (finish-tour tour)
+                                            (ls/set-item! :closed-tour? true)
+                                            (reset! showing? false))
+                             :class "btn-default"
+                             :style {:margin-right "15px"}]]
+                 :style {:display "inline-block"}]
+         :style {:padding-bottom "150px"}]))))
 
 (defn- next-tour-step
   [tour]
@@ -182,6 +185,7 @@
         new-step  (inc old-step)]
     (when (< new-step (count (:steps tour)))
       (reset! (:current-step tour) new-step)
+      (reset! current-step new-step)
       (reset! ((nth steps old-step) tour) false)
       (reset! ((nth steps new-step) tour) true))))
 
@@ -241,7 +245,6 @@
                                 (ls/set-item! :closed-tour? true))
                 :backdrop-opacity 0.5]
       :style (align-style :align-items :stretch)])))
-
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -563,8 +566,8 @@
                                    (dispatch [:set-console-queued-forms :cljs-console (:strings example-map)]))]]
                #(do (finish-tour tour)
                     (reset! showing-atom false)
-                    (utils/scroll-to-top))]
-
+                    (utils/scroll-to-top))
+               #(reset! showing-atom false)]
               [api-example example-map]]])
 
 (defn api-examples
@@ -872,7 +875,7 @@
                         #(do (finish-tour tour)
                              (utils/scroll-to-top))]]
                       [welcome-modal-dialog]
-                      [finished-tour-modal-dialog @(:current-step tour)]]]
+                      [finished-tour-modal-dialog]]]
         (if (= :narrow @media-query)
           [v-box
            :size "1 1 auto"

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -39,7 +39,7 @@
                     [:p "It contains many features, so let’s start!"]]}
    :step1 {:title "Tour 1 of 9"
            :body [:div [:h1.tour-title "Clicking the Bin icon"]
-                  [:p "will reset the REPL, that is:"]
+                  [:p "It will reset the REPL, that is:"]
                   [:ul.tour
                    [:li "it will clear the current prompt"]
                    [:li "it will clear the REPL “screen”"]
@@ -51,23 +51,23 @@
                   [:span "or just by clicking on the item you are interested in."]]}
    :step2 {:title "Tour 2 of 8"
            :body [:div [:h1.tour-title "Clicking the Clear icon"]
-                  [:p "will trigger the same action as before with the difference that the history will not be deleted"]]}
+                  [:p "It will trigger the same action as before with the difference that the history will not be deleted."]]}
    :step3 {:title "Tour 3 of 9"
            :body [:div [:h1.tour-title "Creating a Gist"]
-                  [:p "is really one of the nicest features of our app."]
+                  [:p "It is really one of the nicest features of our app."]
                   [:p "You will need to fill your username and password and a new window with the newly created Gist will be opened."]
                   [:p "The username will be saved (but not the password) so you won’t need to fill it every time."]
-                  [:h4 "note:"]
-                  [:p "only what is shown in the REPL will be sent to Gist. So even if you have some items in your history but the current “screen” is empty you won’t be able to create a Gist."]]}
+                  [:h5 "Note:"]
+                  [:p "Only what is shown in the REPL will be sent to Gist. So even if you have some items in your history but the current “screen” is empty you won’t be able to create a Gist."]]}
    :step4 {:title "Tour 4 of 9"
            :body [:div [:h1.tour-title "Clear examples"]
                   [:p "Just under the REPL you will find many buttons, logically grouped by topic. Clicking on them will open a popup (this feature will be explained in another step of this tutorial)."]
                   [:p "One of the actions you can take is send the examples directly to the REPL:"]
-                  [:span "for example the"]
+                  [:span "For example the"]
                   [:span.symbol " + "]
                   [:span "symbol contains 5 examples you can evaluate. If for any reason you want to interrupt the examples’ evaluation just click on this button."]
-                  [:h4 "note:"]
-                  [:p "the number of current examples to evaluate is shown in the mode-line:"]
+                  [:h5 "Note:"]
+                  [:p "The number of current examples to evaluate is shown in the mode-line:"]
                   [:span.mode "X form(s) in the evaluation queue"]]}
    :step5 {:title "Tour 5 of 9"
            :body [:div [:h1.tour-title "Switch input mode"]
@@ -75,6 +75,7 @@
                   [:a.tour {:href "https://github.com/shaunlebron/parinfer"} " parinfer"]
                   [:span " to our REPL with the default input mode as "]
                   [:span.mode "indent-mode"]
+                  [:span "."]
                   [:p " You can shuffle between three modes:"]
                   [:ul.tour
                    [:li "Indent Mode"]
@@ -82,8 +83,8 @@
                    [:li "none"]]
                   [:span "The "]
                   [:span.mode "non"]
-                  [:span " mode will just disable parinfer and switch to normal editing"]
-                  [:h4 "note:"]
+                  [:span " mode will just disable parinfer and switch to normal editing."]
+                  [:h5 "Note:"]
                   [:span "Our REPL is clever enough to determine whether a form should be evaluated or whether issue a new-line. For example if you are in "]
                   [:span.mode "none"]
                   [:span " mode, write "]
@@ -91,6 +92,7 @@
                   [:span " and press ENTER the cursor will be placed on a newline."]
                   [:span "This is not always the case with Indent Mode, which will try to balance parenthesis causing the previous expression to be transformed to "]
                   [:span.mode "(def a)"]
+                  [:span "."]
                   [:p "If you now press ENTER you’ll receive an error: to overcome this problem just press SHIFT+ENTER to issue a new line."]]}
    :step6 {:title "Tour 6 of 9"
            :body [:div [:h1.tour-title "Console"]
@@ -118,7 +120,7 @@
                    [:li "related symbols list"]]]}
    :step9 {:title  "Tour 9 of 9"
            :body [:div [:h1.tour-title "Send to repl"]
-                  [:p "click on this button to send the examples to the REPL"]]}
+                  [:p "Click on this button to send the examples to the REPL."]]}
    :step10 {:title  "Excellent!"
             :body [:div [:p "This is the end of the tutorial. If you want to report an issue or fork the repository click on the ribbon in the top-left corner."]
                    [:span "Check also our blog at "]
@@ -214,8 +216,10 @@
       (reset! ((nth steps new-step) tour) true))))
 
 (defn tour-buttons
-  [tour another-step close-fn]
-  (let [on-first-button (= @(:current-step tour) 0)
+  [tour another-steps close-fn]
+  (let [next-step (:next another-steps)
+        previous-step (:prev another-steps)
+        on-first-button (= @(:current-step tour) 0)
         on-last-button  (= @(:current-step tour) (dec (count (:steps tour))))
         showing? (reagent/atom true)]
     [:div
@@ -224,14 +228,18 @@
      (when-not on-first-button
        [button
         :label    "Previous"
-        :on-click (handler-fn (prev-tour-step tour))
+        :on-click (handler-fn
+                   (if previous-step
+                     ((previous-step)
+                      (prev-tour-step tour))
+                     (prev-tour-step tour)))
         :style    {:margin-right "15px"}
         :class     "btn-default"])
      [button
       :label    "Next"
       :on-click (handler-fn
-                 (if another-step
-                   ((another-step)
+                 (if next-step
+                   ((next-step)
                     (next-tour-step tour))
                    (next-tour-step tour)))
       :style    {:z-index 5000}
@@ -582,7 +590,7 @@
                #(do (finish-tour tour)
                     (reset! showing-atom false)
                     (utils/scroll-to-top))
-               #(reset! showing-atom false)]
+               {:next #(reset! showing-atom false)}]
               [api-example example-map]]])
 
 (defn api-examples
@@ -648,7 +656,9 @@
                                :on-click #(utils/open-new-window (utils/symbol->clojuredocs-url full-name))]
                               #(do (finish-tour tour)
                                    (reset! showing-atom false)
-                                   (utils/scroll-to-top))]]]
+                                   (utils/scroll-to-top))
+                              {:prev #(reset! showing-atom false)}
+                               ]]]
           :body [reagent/create-class
                  {:component-did-mount (fn [this]
                                          (let [node (reagent/dom-node this)]
@@ -704,15 +714,15 @@
                    #(do (finish-tour tour)
                         (utils/scroll-to-top)
                         (reset! tour? false))
-                   #(do (reset! popover-position :above-center)
-                        (reset! tour? true)
-                        (reset! showing? true)
-                        [popover-anchor-wrapper
-                         :showing? showing?
-                         :position @popover-position
-                         :anchor [button
-                                  :class "btn btn-default api-panel-symbol-button"
-                                  :label (:name symbol)]])]
+                   {:next #(do (reset! popover-position :above-center)
+                               (reset! tour? true)
+                               (reset! showing? true)
+                               [popover-anchor-wrapper
+                                :showing? showing?
+                                :position @popover-position
+                                :anchor [button
+                                         :class "btn btn-default api-panel-symbol-button"
+                                         :label (:name symbol)]])}]
                   (do [popover-anchor-wrapper
                        :showing? showing?
                        :position @popover-position

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -889,6 +889,8 @@
                         [console]
                         #(do (finish-tour tour)
                              (utils/scroll-to-top))]]
+                      [re-complete/completions console-key #(do (dispatch [:console-set-autocompleted-text console-key])
+                                                                (dispatch [:focus-console-editor console-key]))]
                       [welcome-modal-dialog]
                       [finished-tour-modal-dialog]]]
         (if (= :narrow @media-query)

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -893,7 +893,9 @@
 
 (defn repl-component [console-key opts]
   (let [media-query (subscribe [:media-query-size])
-        console (console/console console-key opts)]
+        console (console/console console-key opts)
+        welcome-dialog (welcome-modal-dialog console-key)
+        finished-dialog (finished-tour-modal-dialog console-key)]
     (fn repl-component-form2 []
       (let [children [[cljs-buttons]
                       [v-box
@@ -908,8 +910,8 @@
                         [console]]]
                       [re-complete/completions console-key #(do (dispatch [:console-set-autocompleted-text console-key])
                                                                 (dispatch [:focus-console-editor console-key]))]
-                      [welcome-modal-dialog console-key]
-                      [finished-tour-modal-dialog console-key]]]
+                      [welcome-dialog]
+                      [finished-dialog]]]
         (if (= :narrow @media-query)
           [v-box
            :size "1 1 auto"

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -532,7 +532,7 @@
        :child (if-let [symbol' (get-symbol-doc-map (str symbol))]
                 (if (and (= (str symbol) "/") (not @showing?))
                   [create-tour-step 7
-                   :below-center
+                   :above-center
                    [button
                     :class "btn btn-default api-panel-symbol-button"
                     :label (:name symbol')
@@ -548,13 +548,14 @@
                    #(do (finish-tour tour)
                         (utils/scroll-to-top))
                    #(do (reset! showing? true)
+                        (reset! popover-position :above-center)
                         (popover-anchor-wrapper
                          :showing? showing?
-                         :position :below-center
+                         :position @popover-position
                          :anchor [button
                                   :class "btn btn-default api-panel-symbol-button"
-                                  :label (:name "+")]
-                         :popover [symbol-popover showing? :below-center "+"]))]
+                                  :label (:name "/")]
+                         :popover [symbol-popover showing? popover-position "/"]))]
                   [popover-anchor-wrapper
                    :showing? showing?
                    :position @popover-position
@@ -723,7 +724,7 @@
                       [box
                        :size "0 0 auto"
                        :child
-                       [create-tour-step 6 :above-center [console] #(do (finish-tour tour)
+                       [create-tour-step 6 :below-center [console] #(do (finish-tour tour)
                                                                         (utils/scroll-to-top))]]]]
         (if (= :narrow @media-query)
           [v-box

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -53,7 +53,7 @@
       :position position
       :anchor anchor
       :popover [popover-content-wrapper
-                :showing? (:step2 tour)
+                :showing? (step-keyword tour)
                 :position position
                 :width    "250px"
                 :title    [:strong (get-in tour-steps [step-keyword :title])]
@@ -61,7 +61,7 @@
                            [make-tour-nav tour]]]
       :style  (if style
                 style
-                (align-style :align-self :end))])))
+                (align-style :align-self :center))])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;      Buttons       ;;;
@@ -185,14 +185,16 @@
                     :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
                     :disabled? @can-dump-gist?]
          :popover  [gist-login-dialog-body]]
-        (create-tour-step 4 :below-center [md-icon-button
-                                           :md-icon-name "zmdi-github"
-                                           :on-click #(dispatch [:show-gist-login])
-                                           :class "cljs-btn"
-                                           :size (if-not (= :medium @media-query) :regular :smaller)
-                                           :tooltip "Create Gist"
-                                           :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
-                                           :disabled? @can-dump-gist?])))))
+        [create-tour-step 4
+         :below-center
+         [md-icon-button
+          :md-icon-name "zmdi-github"
+          :on-click #(dispatch [:show-gist-login])
+          :class "cljs-btn"
+          :size (if-not (= :medium @media-query) :regular :smaller)
+          :tooltip "Create Gist"
+          :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
+          :disabled? @can-dump-gist?]]))))
 
 (defn cljs-buttons
   "Return a vector of components containing the cljs console buttons.
@@ -211,39 +213,46 @@
                           (swap! modes rest)
                           next-mode))]
     (fn cljs-buttons-form2 []
-      (let [children [(create-tour-step 2 :below-center
-                                        [md-icon-button
-                                         :md-icon-name "zmdi-delete"
-                                         :on-click #(dispatch [:reset-console-items :cljs-console])
-                                         :class "cljs-btn"
-                                         :size (if-not (= :medium @media-query) :regular :smaller)
-                                         :tooltip "Reset"
-                                         :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
-                                         :disabled? (not @console-created?)])
-                      (create-tour-step 3 :below-center [md-icon-button
-                                                         :md-icon-name "zmdi-format-clear-all"
-                                                         :on-click #(dispatch [:clear-console-items :cljs-console])
-                                                         :class "cljs-btn"
-                                                         :size (if-not (= :medium @media-query) :regular :smaller)
-                                                         :tooltip "Clear"
-                                                         :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
-                                                         :disabled? (not @console-created?)])
+      (let [children [[create-tour-step 2
+                       :below-center
+                       [md-icon-button
+                        :md-icon-name "zmdi-delete"
+                        :on-click #(dispatch [:reset-console-items :cljs-console])
+                        :class "cljs-btn"
+                        :size (if-not (= :medium @media-query) :regular :smaller)
+                        :tooltip "Reset"
+                        :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
+                        :disabled? (not @console-created?)]]
+                      [create-tour-step 3
+                       :below-center
+                       [md-icon-button
+                        :md-icon-name "zmdi-format-clear-all"
+                        :on-click #(dispatch [:clear-console-items :cljs-console])
+                        :class "cljs-btn"
+                        :size (if-not (= :medium @media-query) :regular :smaller)
+                        :tooltip "Clear"
+                        :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
+                        :disabled? (not @console-created?)]]
                       [gist-login-dialog]
-                      (create-tour-step 5 :below-center [md-icon-button
-                                                         :md-icon-name "zmdi-stop"
-                                                         :on-click #(dispatch [:clear-console-queued-forms :cljs-console])
-                                                         :class "cljs-btn"
-                                                         :size (if-not (= :medium @media-query) :regular :smaller)
-                                                         :tooltip "Clear examples"
-                                                         :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
-                                                         :disabled? (not @example-mode?)])
-                      (create-tour-step 6 :below-center [md-icon-button
-                                                         :md-icon-name "zmdi-keyboard"
-                                                         :on-click #(dispatch [:switch-console-mode (get-next-mode)])
-                                                         :class "cljs-btn"
-                                                         :size (if-not (= :medium @media-query) :regular :smaller)
-                                                         :tooltip "Switch input mode"
-                                                         :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)])]]
+                      [create-tour-step 5
+                       :below-center
+                       [md-icon-button
+                        :md-icon-name "zmdi-stop"
+                        :on-click #(dispatch [:clear-console-queued-forms :cljs-console])
+                        :class "cljs-btn"
+                        :size (if-not (= :medium @media-query) :regular :smaller)
+                        :tooltip "Clear examples"
+                        :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)
+                        :disabled? (not @example-mode?)]]
+                      [create-tour-step 6
+                       :below-center
+                       [md-icon-button
+                        :md-icon-name "zmdi-keyboard"
+                        :on-click #(dispatch [:switch-console-mode (get-next-mode)])
+                        :class "cljs-btn"
+                        :size (if-not (= :medium @media-query) :regular :smaller)
+                        :tooltip "Switch input mode"
+                        :tooltip-position (if-not (= :narrow @media-query) :left-center :above-center)]]]]
         (if-not (= :narrow @media-query)
           [v-box
            :gap "8px"
@@ -620,23 +629,23 @@
   (let [media-query (subscribe [:media-query-size])
         console (console/console console-key opts)]
     (fn repl-component-form2 []
-      (let [children [(create-tour-step 1
-                                        :above-center
-                                        [button
-                                         :label    "Start Tour!"
-                                         :on-click #(start-tour tour)
-                                         :style    {:font-weight "bold" :color "yellow"}
-                                         :class    "btn-info"]
-                                        {:width     "34px"
-                                         :font-size "26px"
-                                         :position  "absolute"
-                                         :top       "240px"
-                                         :left      "250px"})
+      (let [children [[create-tour-step 1
+                       :above-center
+                       [button
+                        :label    "Start Tour!"
+                        :on-click #(start-tour tour)
+                        :style    {:font-weight "bold" :color "yellow"}
+                        :class    "btn-info"]
+                       {:width     "34px"
+                        :font-size "26px"
+                        :position  "absolute"
+                        :top       "240px"
+                        :left      "250px"}]
                       [cljs-buttons]
                       [box
                        :size "0 0 auto"
                        :child
-                       (create-tour-step 7 :above-center [console])]]]
+                       [create-tour-step 7 :above-center [console]]]]]
         (if (= :narrow @media-query)
           [v-box
            :size "1 1 auto"

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -491,10 +491,11 @@
   [v-box
    :size "0 0 auto"
    :gap "2px"
-   :children [(for [s signatures]
-                ^{:key s} [label
-                           :label s
-                           :class "api-panel-signature"])]])
+   :children [(for [[index s] (map-indexed vector signatures)]
+                ^{:key index}
+                [label
+                 :label s
+                 :class "api-panel-signature"])]])
 
 (defn api-symbol-description
   "Builds the UI for the symbol's description in the popover. Desc needs
@@ -812,8 +813,8 @@
       [h-box
        :size "1 1 auto"
        :gap "10px"
-       :children (for [sections @sections-by-column]
-                   ^{:key sections}
+       :children (for [[index sections] (map-indexed vector @sections-by-column)]
+                   ^{:key index}
                    [v-box
                     :size (str "0 1 " (quot 100 @column-number) "%")
                     :gap "10px"

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -231,10 +231,9 @@
      [button
       :label    "Next"
       :on-click (handler-fn
-                 (if next-step
-                   ((next-step)
-                    (next-tour-step tour))
-                   (next-tour-step tour)))
+                 (when next-step
+                   (next-step))
+                 (next-tour-step tour))
       :style    {:z-index 5000}
       :class     "btn-default"]]))
 

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -74,23 +74,15 @@
                   [:a.tour {:href "https://github.com/shaunlebron"} " shaunlebron"]
                   [:span "’s excellent"]
                   [:a.tour {:href "https://github.com/shaunlebron/parinfer"} " parinfer"]
-                  [:span " to our REPL with the default input mode as "]
-                  [:i "Indent Mode"]
-                  [:span "."]
-                  [:p " You can shuffle between three modes: Indent Mode, Paren Mode and none."]
-                  [:span "The "]
-                  [:i "none"]
-                  [:span " mode will just disable parinfer and switch to normal editing."]
+                  [:span " to our REPL with the default input mode as Indent Mode (the other two being Paren Mode and none)."]
                   [:h5 "Note:"]
-                  [:span "Our REPL is clever enough to determine whether a form should be evaluated or whether issue a newline. For example if you are in "]
-                  [:i "none"]
-                  [:span " mode, write "]
+                  [:span "If you write for exmaple "]
                   [:span.mode "(def a"]
-                  [:span " and press ENTER the cursor will be placed on a newline."]
+                  [:span " and press ENTER the cursor will be placed on a newline automatically (none mode)."]
                   [:span "This is not always the case with Indent Mode, which will try to balance parenthesis causing the previous expression to be transformed to "]
                   [:span.mode "(def a)"]
                   [:span "."]
-                  [:p "If you now press ENTER you’ll receive an error: to overcome this problem and issue a newline  just press SHIFT+ENTER."]]}
+                  [:p "In this case you need to press SHIFT+ENTER."]]}
    :step6 {:title "Tour 6 of 9"
            :body [:div [:h1.tour-title "Console"]
                   [:p "We already saw many features of the REPL like history navigation, input mode or examples evaluation (more on this in the next step)."]
@@ -421,8 +413,8 @@
                           next-mode))]
     (fn cljs-buttons-form2 []
       (let [children [[create-tour-step 1
-                       (if (= @media-query :narrow) :below-center :right-center)
-                       (if (= @media-query :narrow) "240px" "400px")
+                       (if (= @media-query :narrow) :below-right :right-center)
+                       (if (= @media-query :narrow) "230px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-delete"
                         :on-click #(dispatch [:reset-console-items :cljs-console])
@@ -434,7 +426,7 @@
                        #(finish-tour tour)]
                       [create-tour-step 2
                        (if (= @media-query :narrow) :below-center :right-center)
-                       (if (= @media-query :narrow) "300px" "400px")
+                       (if (= @media-query :narrow) "240px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-format-clear-all"
                         :on-click #(dispatch [:clear-console-items :cljs-console])
@@ -447,7 +439,7 @@
                       [gist-login-dialog]
                       [create-tour-step 4
                        (if (= @media-query :narrow) :below-center :right-center)
-                       (if (= @media-query :narrow) "250px" "400px")
+                       (if (= @media-query :narrow) "240px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-stop"
                         :on-click #(dispatch [:clear-console-queued-forms :cljs-console])
@@ -459,7 +451,7 @@
                        #(finish-tour tour)]
                       [create-tour-step 5
                        (if (= @media-query :narrow) :below-left :right-center)
-                       (if (= @media-query :narrow) "260px" "400px")
+                       (if (= @media-query :narrow) "240px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-keyboard"
                         :on-click #(dispatch [:switch-console-mode (get-next-mode)])
@@ -639,7 +631,7 @@
                                         ; formatting (like paragraphs)
              examples (map (fn [html string] {:html html :strings string}) examples-htmls examples-strings)
              popover-width  (if (= :narrow @media-query) 280 400)
-             popover-height (if (= :narrow @media-query) 250 400)
+             popover-height (if (= :narrow @media-query) 300 400)
              popover-content-width (- popover-width (* 2 14) 15)] ; bootstrap padding + scrollbar width
          [popover-content-wrapper
           :showing? showing-atom
@@ -709,8 +701,8 @@
        :child (if-let [symbol' (get-symbol-doc-map (str symbol))]
                 (if (and (= (str symbol) "/") (not @showing?))
                   [create-tour-step 7
-                   :above-center
-                   (if (= @media-query :narrow) "280px" "400px")
+                   :above-left
+                   (if (= @media-query :narrow) "200px" "280px")
                    [button
                     :class "btn btn-default api-panel-symbol-button"
                     :label (:name symbol')

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -38,7 +38,7 @@
              :body [:div [:p "Here you will find a terminal-like REPL which you can use when learning Clojure/ClojureScript or just trying new things out."]
                     [:p "It contains many features, so let’s start!"]]}
    :step1 {:title "Tour 1 of 9"
-           :body [:div [:h1.tour-title "Clicking the Bin icon"]
+           :body [:div [:h1.tour-title "Reset button"]
                   [:p "It will reset the REPL, that is:"]
                   [:ul.tour
                    [:li "it will clear the current prompt"]
@@ -50,7 +50,7 @@
                   [:span.symbol " ↓ "]
                   [:span "or just by clicking on the item you are interested in."]]}
    :step2 {:title "Tour 2 of 8"
-           :body [:div [:h1.tour-title "Clicking the Clear icon"]
+           :body [:div [:h1.tour-title "Clear button"]
                   [:p "It will trigger the same action as before with the difference that the history will not be deleted."]]}
    :step3 {:title "Tour 3 of 9"
            :body [:div [:h1.tour-title "Creating a Gist"]
@@ -62,49 +62,46 @@
    :step4 {:title "Tour 4 of 9"
            :body [:div [:h1.tour-title "Clear examples"]
                   [:p "Just under the REPL you will find many buttons, logically grouped by topic. Clicking on them will open a popup (this feature will be explained in another step of this tutorial)."]
-                  [:p "One of the actions you can take is send the examples directly to the REPL:"]
-                  [:span "For example the"]
+                  [:span "One of the actions you can take is send the examples directly to the REPL: for example the"]
                   [:span.symbol " + "]
                   [:span "symbol contains 5 examples you can evaluate. If for any reason you want to interrupt the examples’ evaluation just click on this button."]
                   [:h5 "Note:"]
-                  [:p "The number of current examples to evaluate is shown in the mode-line:"]
-                  [:span.mode "X form(s) in the evaluation queue"]]}
+                  [:span "The number of current examples to evaluate is shown in the mode-line:"]
+                  [:code "X form(s) in the evaluation queue"]]}
    :step5 {:title "Tour 5 of 9"
            :body [:div [:h1.tour-title "Switch input mode"]
-                  [:span "We integrated shaunlebron’s excellent"]
+                  [:span "We integrated"]
+                  [:a.tour {:href "https://github.com/shaunlebron"} " shaunlebron"]
+                  [:span "’s excellent"]
                   [:a.tour {:href "https://github.com/shaunlebron/parinfer"} " parinfer"]
                   [:span " to our REPL with the default input mode as "]
-                  [:span.mode "indent-mode"]
+                  [:i "Indent Mode"]
                   [:span "."]
-                  [:p " You can shuffle between three modes:"]
-                  [:ul.tour
-                   [:li "Indent Mode"]
-                   [:li "Parent Mode"]
-                   [:li "none"]]
+                  [:p " You can shuffle between three modes: Indent Mode, Paren Mode and none."]
                   [:span "The "]
-                  [:span.mode "non"]
+                  [:i "none"]
                   [:span " mode will just disable parinfer and switch to normal editing."]
                   [:h5 "Note:"]
-                  [:span "Our REPL is clever enough to determine whether a form should be evaluated or whether issue a new-line. For example if you are in "]
-                  [:span.mode "none"]
+                  [:span "Our REPL is clever enough to determine whether a form should be evaluated or whether issue a newline. For example if you are in "]
+                  [:i "none"]
                   [:span " mode, write "]
                   [:span.mode "(def a"]
                   [:span " and press ENTER the cursor will be placed on a newline."]
                   [:span "This is not always the case with Indent Mode, which will try to balance parenthesis causing the previous expression to be transformed to "]
                   [:span.mode "(def a)"]
                   [:span "."]
-                  [:p "If you now press ENTER you’ll receive an error: to overcome this problem just press SHIFT+ENTER to issue a new line."]]}
+                  [:p "If you now press ENTER you’ll receive an error: to overcome this problem and issue a newline  just press SHIFT+ENTER."]]}
    :step6 {:title "Tour 6 of 9"
            :body [:div [:h1.tour-title "Console"]
-                  [:p "We already saw many feature of the REPL like history navigation, input mode or examples evaluation (more on this in the next step)."]
-                  [:p "Another feature we want to mention here is the autocompletion feature:"]
+                  [:p "We already saw many features of the REPL like history navigation, input mode or examples evaluation (more on this in the next step)."]
+                  [:p "Another feature we want to mention here is autocompletion:"]
                   [:ul.tour]
-                  [:span "The suggestion list is shown immediately when user starts typing. The word to autocomplete is selected by using"]
+                  [:span "The suggestion list is shown immediately when the user starts typing. The word to autocomplete is selected by using"]
                   [:span.symbol " ↑ "]
                   [:span "and"]
                   [:span.symbol " ↓ "]
                   [:span "arrows, or by clicking on the selected item."]
-                  [:span " When user presses "]
+                  [:span " When the user presses "]
                   [:span.mode "tab"]
                   [:span " the first item from suggestion list is picked for autocompletion."]]}
    :step7 {:title "Tour 7 of 9"
@@ -117,6 +114,7 @@
                   [:ul.tour
                    [:li "the (i) icon will open the relative online doc page"]
                    [:li "signatures"]
+                   [:li "description"]
                    [:li "related symbols list"]]]}
    :step9 {:title  "Tour 9 of 9"
            :body [:div [:h1.tour-title "Send to repl"]
@@ -152,14 +150,14 @@
                             [p (get-in tour-steps [:welcome :body])]
                             [:hr {:style {:margin "10px 0 10px"}}]
                             [button
-                             :label "skip"
+                             :label "Skip"
                              :on-click #(do (finish-tour tour)
                                             (ls/set-item! :closed-tour? true)
                                             (reset! showing? false))
                              :class "btn-default"
                              :style {:margin-right "15px"}]
                             [button
-                             :label "next"
+                             :label "Next"
                              :on-click #(do (start-tour tour)
                                             (reset! showing? false))
                              :class "btn-default"]]
@@ -186,7 +184,7 @@
                             [p (get-in tour-steps [:step10 :body])]
                             [:hr {:style {:margin "10px 0 10px"}}]
                             [button
-                             :label "finish"
+                             :label "Finish"
                              :on-click #(do (finish-tour tour)
                                             (ls/set-item! :closed-tour? true)
                                             (reset! showing? false))
@@ -247,11 +245,12 @@
       :class     "btn-default"]]))
 
 (defn create-tour-step
-  ([step position anchor close-fn]
-   (create-tour-step step position anchor close-fn nil))
-  ([step position anchor close-fn another-step]
+  ([step position width anchor close-fn]
+   (let [media-query (subscribe [:media-query-size])]
+     (create-tour-step step position width anchor close-fn nil)))
+  ([step position width anchor close-fn another-step]
    (let [step-keyword (keyword (str "step" step))
-         media-query (subscribe [:media-query-size])]
+         media-query  (subscribe [:media-query-size])]
      [popover-anchor-wrapper
       :showing? (step-keyword tour)
       :position position
@@ -259,10 +258,7 @@
       :popover [popover-content-wrapper
                 :showing? (step-keyword tour)
                 :position position
-                :width     (if (or (= @current-step (dec 9))
-                                   (= :narrow @media-query))
-                             "200px"
-                             "400px")
+                :width    width
                 :title    [:strong (get-in tour-steps [step-keyword :title])]
                 :body     [:div (get-in tour-steps [step-keyword :body])
                            [tour-buttons tour another-step close-fn]]
@@ -395,7 +391,8 @@
                     :disabled? @can-dump-gist?]
          :popover  [gist-login-dialog-body]]
         [create-tour-step 3
-         :below-center
+         (if (= @media-query :narrow) :below-center :right-center)
+         (if (= @media-query :narrow) "300px" "400px")
          [md-icon-button
           :md-icon-name "zmdi-github"
           :on-click #(dispatch [:show-gist-login])
@@ -424,7 +421,8 @@
                           next-mode))]
     (fn cljs-buttons-form2 []
       (let [children [[create-tour-step 1
-                       :below-center
+                       (if (= @media-query :narrow) :below-center :right-center)
+                       (if (= @media-query :narrow) "240px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-delete"
                         :on-click #(dispatch [:reset-console-items :cljs-console])
@@ -435,7 +433,8 @@
                         :disabled? (not @console-created?)]
                        #(finish-tour tour)]
                       [create-tour-step 2
-                       :below-center
+                       (if (= @media-query :narrow) :below-center :right-center)
+                       (if (= @media-query :narrow) "300px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-format-clear-all"
                         :on-click #(dispatch [:clear-console-items :cljs-console])
@@ -447,7 +446,8 @@
                        #(finish-tour tour)]
                       [gist-login-dialog]
                       [create-tour-step 4
-                       :below-center
+                       (if (= @media-query :narrow) :below-center :right-center)
+                       (if (= @media-query :narrow) "250px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-stop"
                         :on-click #(dispatch [:clear-console-queued-forms :cljs-console])
@@ -458,7 +458,8 @@
                         :disabled? (not @example-mode?)]
                        #(finish-tour tour)]
                       [create-tour-step 5
-                       :below-center
+                       (if (= @media-query :narrow) :below-left :right-center)
+                       (if (= @media-query :narrow) "260px" "400px")
                        [md-icon-button
                         :md-icon-name "zmdi-keyboard"
                         :on-click #(dispatch [:switch-console-mode (get-next-mode)])
@@ -561,39 +562,44 @@
 
 (defn api-example-panel
   "UI for a single example. Wants a map {:html ... :strings}."
-  [showing-atom example-index example-map]
-  {:pre [(:strings example-map) (:html example-map)]}
-  [v-box
-   :size "none"
-   :gap "4px"
-   :justify :center
-   ;; Why the box?
-   ;; See problem here, see https://github.com/Day8/re-com/issues/76
-   :children [[create-tour-step 9 :above-center
-               [box
-                :class "api-panel-button-send-repl-box"
-                :size "1 0 auto"
-                :style (align-style :align-items :stretch)
-                :child [button
-                        :class "btn btn-default api-panel-button-send-repl"
-                        :style (merge (flex-child-style "1 0 auto")
-                                      {:width "100%"})
-                        :disabled? (not @(subscribe [:console-created? :cljs-console]))
-                        :label [h-box
-                                :size "1 1 auto"
-                                :justify :between
-                                :align :center
-                                :children [[example-number-icon example-index]
-                                           [example-send-to-repl-button-label example-index example-map]]]
-                        :on-click (handler-fn
-                                   (reset! showing-atom false)
-                                   (utils/scroll-to-top) ; in case we are at the bottom of the page
-                                   (dispatch [:set-console-queued-forms :cljs-console (:strings example-map)]))]]
-               #(do (finish-tour tour)
-                    (reset! showing-atom false)
-                    (utils/scroll-to-top))
-               {:next #(reset! showing-atom false)}]
-              [api-example example-map]]])
+  []
+  (let [media-query (subscribe [:media-query-size])]
+    (fn
+      [showing-atom example-index example-map]
+      {:pre [(:strings example-map) (:html example-map)]}
+      [v-box
+       :size "none"
+       :gap "4px"
+       :justify :center
+       ;; Why the box?
+       ;; See problem here, see https://github.com/Day8/re-com/issues/76
+       :children [[create-tour-step 9
+                   :above-center
+                   (if (= @media-query :narrow) "200px" "300px")
+                   [box
+                    :class "api-panel-button-send-repl-box"
+                    :size "1 0 auto"
+                    :style (align-style :align-items :stretch)
+                    :child [button
+                            :class "btn btn-default api-panel-button-send-repl"
+                            :style (merge (flex-child-style "1 0 auto")
+                                          {:width "100%"})
+                            :disabled? (not @(subscribe [:console-created? :cljs-console]))
+                            :label [h-box
+                                    :size "1 1 auto"
+                                    :justify :between
+                                    :align :center
+                                    :children [[example-number-icon example-index]
+                                               [example-send-to-repl-button-label example-index example-map]]]
+                            :on-click (handler-fn
+                                       (reset! showing-atom false)
+                                       (utils/scroll-to-top) ; in case we are at the bottom of the page
+                                       (dispatch [:set-console-queued-forms :cljs-console (:strings example-map)]))]]
+                   #(do (finish-tour tour)
+                        (reset! showing-atom false)
+                        (utils/scroll-to-top))
+                   {:next #(reset! showing-atom false)}]
+                  [api-example example-map]]])))
 
 (defn api-examples
   "Builds the UI for the symbol's examples. Wants a list of {:html ... :strings}."
@@ -608,7 +614,7 @@
               [v-box
                :size "0 0 auto"
                :gap "2px"
-               :children (map-indexed (partial api-example-panel showing-atom) examples-map)]]])
+               :children (map-indexed (partial (api-example-panel) showing-atom) examples-map)]]])
 
 (defn symbol-popover
   "A popover's body in which details of the given symbol will be shown."
@@ -648,7 +654,9 @@
                   :children [[title
                               :label name
                               :level :level4]
-                             [create-tour-step 8 :below-center
+                             [create-tour-step 8
+                              (if (= @media-query :narrow) :below-center :right-below)
+                              (if (= @media-query :narrow) "220px" "400px")
                               [md-icon-button
                                :md-icon-name "zmdi-info"
                                :tooltip "See online documentation"
@@ -659,8 +667,7 @@
                               #(do (finish-tour tour)
                                    (reset! showing-atom false)
                                    (utils/scroll-to-top))
-                              {:prev #(reset! showing-atom false)}
-                               ]]]
+                              {:prev #(reset! showing-atom false)}]]]
           :body [reagent/create-class
                  {:component-did-mount (fn [this]
                                          (let [node (reagent/dom-node this)]
@@ -691,7 +698,8 @@
   [symbol]
   (let [showing? (reagent/atom false)
         popover-position (reagent/atom :below-center)
-        tour? (reagent/atom false)]
+        tour? (reagent/atom false)
+        media-query (subscribe [:media-query-size])]
     (fn api-symbol-form2 [symbol]
       [box
        :size "0 1 auto"
@@ -701,6 +709,7 @@
                 (if (and (= (str symbol) "/") (not @showing?))
                   [create-tour-step 7
                    :above-center
+                   (if (= @media-query :narrow) "280px" "400px")
                    [button
                     :class "btn btn-default api-panel-symbol-button"
                     :label (:name symbol')
@@ -895,9 +904,9 @@
                       [box
                        :size "0 0 auto"
                        :child
-                       [create-tour-step
-                        6
+                       [create-tour-step 6
                         :below-center
+                        (if (= @media-query :narrow) "300px" "400px")
                         [console]
                         #(do (finish-tour tour)
                              (utils/scroll-to-top))]]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -902,15 +902,16 @@
         console (console/console console-key opts)]
     (fn repl-component-form2 []
       (let [children [[cljs-buttons]
-                      [box
+                      [v-box
                        :size "0 0 auto"
-                       :child
-                       [create-tour-step 6
-                        :below-center
-                        (if (= @media-query :narrow) "300px" "400px")
-                        [console]
-                        #(do (finish-tour tour)
-                             (utils/scroll-to-top))]]
+                       :children
+                       [[create-tour-step 6
+                         :below-center
+                         (if (= @media-query :narrow) "300px" "400px")
+                         [:div.popup-tour-console-anchor]
+                         #(do (finish-tour tour)
+                              (utils/scroll-to-top))]
+                        [console]]]
                       [re-complete/completions console-key #(do (dispatch [:console-set-autocompleted-text console-key])
                                                                 (dispatch [:focus-console-editor console-key]))]
                       [welcome-modal-dialog]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -212,6 +212,7 @@
         new-step (dec old-step)]
     (when (>= new-step 0)
       (reset! (:current-step tour) new-step)
+      (reset! current-step new-step)
       (reset! ((nth steps old-step) tour) false)
       (reset! ((nth steps new-step) tour) true))))
 
@@ -258,7 +259,8 @@
       :popover [popover-content-wrapper
                 :showing? (step-keyword tour)
                 :position position
-                :width     (if (or (= @current-step (dec 9)) (= :narrow @media-query))
+                :width     (if (or (= @current-step (dec 9))
+                                   (= :narrow @media-query))
                              "200px"
                              "400px")
                 :title    [:strong (get-in tour-steps [step-keyword :title])]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -71,7 +71,9 @@
                   [:span.mode "X form(s) in the evaluation queue"]]}
    :step5 {:title "Tour 5 of 9"
            :body [:div [:h1.tour-title "Switch input mode"]
-                  [:span "We integrated shaunlebron’s excellent [parinfer](https://github.com/shaunlebron/parinfer) to our REPL with the default input mode as "]
+                  [:span "We integrated shaunlebron’s excellent"]
+                  [:a.tour {:href "https://github.com/shaunlebron/parinfer"} " parinfer"]
+                  [:span " to our REPL with the default input mode as "]
                   [:span.mode "indent-mode"]
                   [:p " You can shuffle between three modes:"]
                   [:ul.tour
@@ -93,7 +95,16 @@
    :step6 {:title "Tour 6 of 9"
            :body [:div [:h1.tour-title "Console"]
                   [:p "We already saw many feature of the REPL like history navigation, input mode or examples evaluation (more on this in the next step)."]
-                  [:p "Another feature we want to mention here is the autocompletion feature:"]]}
+                  [:p "Another feature we want to mention here is the autocompletion feature:"]
+                  [:ul.tour]
+                  [:span "The suggestion list is shown immediately when user starts typing. The word to autocomplete is selected by using"]
+                  [:span.symbol " ↑ "]
+                  [:span "and"]
+                  [:span.symbol " ↓ "]
+                  [:span "arrows, or by clicking on the selected item."]
+                  [:span " When user presses "]
+                  [:span.mode "tab"]
+                  [:span " the first item from suggestion list is picked for autocompletion."]]}
    :step7 {:title "Tour 7 of 9"
            :body [:div [:h1.tour-title "Symbol"]
                   [:p "As mentioned earlier there are many buttons in the lower section of the page."]
@@ -110,7 +121,12 @@
                   [:p "click on this button to send the examples to the REPL"]]}
    :step10 {:title  "Excellent!"
             :body [:div [:p "This is the end of the tutorial. If you want to report an issue or fork the repository click on the ribbon in the top-left corner."]
-                   [:p "Check also our blog at lambdax.io/blog for posts about Clojure and follow us on Twitter at @lambdax_io."]
+                   [:span "Check also our blog at "]
+                   [:a {:href "http://lambdax.io/blog"} "lambdax.io/blog"]
+                   [:span " for posts about Clojure and follow us on Twitter at"]
+                   [:a {:href "https://twitter.com/lambdax_io"} " @lambdax_io"]
+                   [:span "."]
+                   [:p]
                    [:p "Thanks and enjoy."]]}})
 
 (defn welcome-modal-dialog
@@ -124,7 +140,7 @@
          :child [v-box
                  :align :center
                  :max-width "400px"
-                 :class "welcome-popup"
+                 :class "modal-tour-popup"
                  :children [[title
                              :label (get-in tour-steps [:welcome :title])
                              :style {:font-weight "bold"
@@ -152,14 +168,13 @@
   []
   (let [showing? (reagent/atom true)]
     (fn []
-      (.log js/console "current-step?" @current-step)
       (when (and @showing? (= @current-step (dec (count (:steps tour)))))
         [modal-panel
          :backdrop-opacity 0.4
          :child [v-box
                  :align :center
                  :max-width "400px"
-                 :class "welcome-popup"
+                 :class "modal-tour-popup"
                  :children [[title
                              :label (get-in tour-steps [:step10 :title])
                              :style {:font-weight "bold"
@@ -199,9 +214,6 @@
       (reset! ((nth steps new-step) tour) true))))
 
 (defn tour-buttons
-  "Generate the hr and previous/next buttons markup.
-  If first button in tour, don't generate a Previous button.
-  If last button in tour, change Next button to a Finish button"
   [tour another-step close-fn]
   (let [on-first-button (= @(:current-step tour) 0)
         on-last-button  (= @(:current-step tour) (dec (count (:steps tour))))
@@ -229,7 +241,8 @@
   ([step position anchor close-fn]
    (create-tour-step step position anchor close-fn nil))
   ([step position anchor close-fn another-step]
-   (let [step-keyword (keyword (str "step" step))]
+   (let [step-keyword (keyword (str "step" step))
+         media-query (subscribe [:media-query-size])]
      [popover-anchor-wrapper
       :showing? (step-keyword tour)
       :position position
@@ -237,7 +250,9 @@
       :popover [popover-content-wrapper
                 :showing? (step-keyword tour)
                 :position position
-                :width    "200px"
+                :width     (if (or (= @current-step (dec 9)) (= :narrow @media-query))
+                             "200px"
+                             "400px")
                 :title    [:strong (get-in tour-steps [step-keyword :title])]
                 :body     [:div (get-in tour-steps [step-keyword :body])
                            [tour-buttons tour another-step close-fn]]

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -117,7 +117,9 @@
                            [tour-buttons tour another-step]]
                 :on-cancel #(do (finish-tour tour)
                                 (local-storage/set-item! :closed-tour? true))
-                :backdrop-opacity 0.5]
+                :backdrop-opacity 0.5
+                ]
+      :style (align-style :align-items :stretch)
       ;;:style (align-style :align-self)
       ])))
 
@@ -418,6 +420,7 @@
                [box
                 :class "api-panel-button-send-repl-box"
                 :size "1 0 auto"
+                :style (align-style :align-items :stretch)
                 :child [button
                         :class "btn btn-default api-panel-button-send-repl"
                         :style (merge (flex-child-style "1 0 auto")
@@ -525,7 +528,7 @@
        :align :center
        :class "api-panel-symbol-label-box"
        :child (if-let [symbol' (get-symbol-doc-map (str symbol))]
-                (if (and (= (str symbol) "+") (not @showing?))
+                (if (and (= (str symbol) "/") (not @showing?))
                   [create-tour-step 7
                    :below-center
                    [button

--- a/src/cljs/cljs_repl_web/views.cljs
+++ b/src/cljs/cljs_repl_web/views.cljs
@@ -122,7 +122,7 @@
                    [:p "Thanks and enjoy."]]}})
 
 (defn welcome-modal-dialog
-  []
+  [console-key]
   (let [showing? (reagent/atom true)
         closed-tour? (ls/get-item :closed-tour?)]
     (fn []
@@ -145,7 +145,8 @@
                              :label "Skip"
                              :on-click #(do (finish-tour tour)
                                             (ls/set-item! :closed-tour? true)
-                                            (reset! showing? false))
+                                            (reset! showing? false)
+                                            (dispatch [:focus-console-editor console-key]))
                              :class "btn-default"
                              :style {:margin-right "15px"}]
                             [button
@@ -157,7 +158,7 @@
          :style {:padding-bottom "150px"}]))))
 
 (defn finished-tour-modal-dialog
-  []
+  [console-key]
   (let [showing? (reagent/atom true)]
     (fn []
       (when (and @showing? (= @current-step (dec (count (:steps tour)))))
@@ -179,7 +180,8 @@
                              :label "Finish"
                              :on-click #(do (finish-tour tour)
                                             (ls/set-item! :closed-tour? true)
-                                            (reset! showing? false))
+                                            (reset! showing? false)
+                                            (dispatch [:focus-console-editor console-key]))
                              :class "btn-default"
                              :style {:margin-right "15px"}]]
                  :style {:display "inline-block"}]
@@ -906,8 +908,8 @@
                         [console]]]
                       [re-complete/completions console-key #(do (dispatch [:console-set-autocompleted-text console-key])
                                                                 (dispatch [:focus-console-editor console-key]))]
-                      [welcome-modal-dialog]
-                      [finished-tour-modal-dialog]]]
+                      [welcome-modal-dialog console-key]
+                      [finished-tour-modal-dialog console-key]]]
         (if (= :narrow @media-query)
           [v-box
            :size "1 1 auto"


### PR DESCRIPTION
**Parts of the popup-tour are for now:**
* Start tour button
* Reset
* Clear
* Create gist
* Clear examples
* Switch input mode
* Console

![eplumb repl20160427183817](https://cloud.githubusercontent.com/assets/9211809/14859976/dc6debfc-0ca6-11e6-879e-8caf77843aae.gif)

Questions: 
* What else should be the part of the tour? 
* We need to think about texts for the tour. 
* We need to change the design of the pop-up tour to match the rest of the site (maybe design of the whole page as we were talking).

@tomasz-biernacki @arichiardi 

