### PR TITLE
docs: fix return of (flatten nil)

### DIFF
--- a/src/cljs/cljs_repl_web/cljs_api.cljs
+++ b/src/cljs/cljs_repl_web/cljs_api.cljs
@@ -1668,14 +1668,14 @@
    "f should be a function of 2 arguments. If val is not supplied,\nreturns the result of applying f to the first 2 items in coll, then\napplying f to that result and the 3rd item, etc. If coll contains no\nitems, f must accept no arguments as well, and reduce returns the\nresult of calling f with no arguments.  If coll has only 1 item, it\nis returned and f is not called.  If val is supplied, returns the\nresult of applying f to val and the first item in coll, then\napplying f to that result and the 2nd item, etc. If coll contains no\nitems, returns val and f is not called."},
   "flatten"
   {:description
-   "Takes any nested combination of sequential things (lists, vectors, etc.) and\nreturns their contents as a single, flat sequence.\n\n`(flatten nil)` returns nil.",
+   "Takes any nested combination of sequential things (lists, vectors, etc.) and\nreturns their contents as a single, flat sequence.\n\n`(flatten nil)` returns `()`.",
    :ns "cljs.core",
    :name "flatten",
    :signature ["[x]"],
    :type "function",
    :full-name "cljs.core/flatten",
    :docstring
-   "Takes any nested combination of sequential things (lists, vectors,\netc.) and returns their contents as a single, flat sequence.\n(flatten nil) returns nil.",
+   "Takes any nested combination of sequential things (lists, vectors,\netc.) and returns their contents as a single, flat sequence.\n(flatten nil) returns ().",
    :examples-strings [],
    :examples-htmls []},
   "repeatedly"


### PR DESCRIPTION
Simple docs correction: `(flatten nil)` actually returns `()`, not `nil`.